### PR TITLE
Remove configurations for TrustStore

### DIFF
--- a/influent-java-sample/src/main/java/sample/TLSPrint.java
+++ b/influent-java-sample/src/main/java/sample/TLSPrint.java
@@ -1,11 +1,28 @@
+/*
+ * Copyright 2016 okumin
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package sample;
 
-import influent.forward.ForwardCallback;
-import influent.forward.ForwardServer;
+import java.util.concurrent.Executors;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.util.concurrent.Executors;
+import influent.forward.ForwardCallback;
+import influent.forward.ForwardServer;
 
 public class TLSPrint {
   private static final Logger logger = LoggerFactory.getLogger(Print.class);
@@ -22,11 +39,9 @@ public class TLSPrint {
         new ForwardServer.Builder(callback)
             .sslEnabled(true)
             .tlsVersions(new String[]{"TLSv1.2"})
-            .keystorePath("/home/kenji/wc/influent/keystore.jks")
+            .keystorePath("./out/influent-server.jks")
             .keystorePassword("password")
             .keyPassword("password")
-            .truststorePath("/home/kenji/wc/influent/keystore.jks")
-            .truststorePassword("password")
             .build();
     server.start();
 

--- a/influent-java/src/main/java/influent/forward/ForwardServer.java
+++ b/influent-java/src/main/java/influent/forward/ForwardServer.java
@@ -16,14 +16,14 @@
 
 package influent.forward;
 
-import influent.internal.nio.NioChannelConfig;
-
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.util.Objects;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ThreadFactory;
+
+import influent.internal.nio.NioChannelConfig;
 
 /**
  * A server which accepts requests of Fluentd's forward protocol.
@@ -53,8 +53,6 @@ public interface ForwardServer {
     private String keystorePath = null;
     private String keystorePassword = null;
     private String keyPassword = null;
-    private String truststorePath = null;
-    private String truststorePassword = null;
 
     /**
      * Constructs a new {@code ForwardServer.Builder}.
@@ -216,7 +214,7 @@ public interface ForwardServer {
      * @param value the cipher suites
      * @return this builder
      */
-    public Builder ciphers(String[] value) {
+    public Builder ciphers(final String[] value) {
       ciphers = value;
       return this;
     }
@@ -255,28 +253,6 @@ public interface ForwardServer {
     }
 
     /**
-     * Set path for keystore that stores trusted certs.
-     *
-     * @param value path for keystore that stores trusted certs
-     * @return this builder
-     */
-    public Builder truststorePath(final String value) {
-      truststorePath = value;
-      return this;
-    }
-
-    /**
-     * Set password for keystore that stores trusted certs
-     *
-     * @param value password for keystore that stores trusted certs
-     * @return this builder
-     */
-    public Builder truststorePassword(final String value) {
-      truststorePassword = value;
-      return this;
-    }
-
-    /**
      * Creates a new {@code ForwardServer}.
      *
      * @return the new {@code ForwardServer}
@@ -285,12 +261,11 @@ public interface ForwardServer {
      * @throws influent.exception.InfluentIOException if some IO error occurs
      */
     public ForwardServer build() {
-      InetSocketAddress address = (InetSocketAddress) localAddress;
-      NioChannelConfig channelConfig = new NioChannelConfig(
+      final InetSocketAddress address = (InetSocketAddress) localAddress;
+      final NioChannelConfig channelConfig = new NioChannelConfig(
           address.getHostName(), address.getPort(),
           sslEnabled, tlsVersions, ciphers,
-          keystorePath, keystorePassword, keyPassword,
-          truststorePath, truststorePassword
+          keystorePath, keystorePassword, keyPassword
       );
       return new NioForwardServer(
           localAddress,


### PR DESCRIPTION
TrustStore is not used because Fluetnd does not try client authentication on SSL/TLS layer.
Influent requires that server's key and certificate are prepared at first
while fluent-plugin-secure-forward generates those from private CA.
When server's key and certificate exist, only client requires CA's certificate.
So Influent need no TrustStore configuration.