### PR TITLE
Don't read channel on MsgpackStreamUnpacker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,3 +6,4 @@ scala:
 jdk:
   - oraclejdk8
 
+sudo: true

--- a/influent-java/src/main/java/influent/internal/msgpack/InfluentByteBuffer.java
+++ b/influent-java/src/main/java/influent/internal/msgpack/InfluentByteBuffer.java
@@ -19,12 +19,11 @@ package influent.internal.msgpack;
 import java.nio.ByteBuffer;
 import java.util.Deque;
 import java.util.LinkedList;
+import java.util.function.Supplier;
 
 import influent.internal.nio.NioTcpChannel;
 
 final class InfluentByteBuffer {
-  private static final int BUFFER_SIZE = 1024;
-
   private final Deque<ByteBuffer> buffers = new LinkedList<>();
   private long remaining = 0;
   private long bufferSizeLimit;
@@ -34,7 +33,6 @@ final class InfluentByteBuffer {
   }
 
   void push(final ByteBuffer buffer) {
-    buffer.flip();
     remaining += buffer.remaining();
     buffers.addLast(buffer.slice());
   }
@@ -64,12 +62,11 @@ final class InfluentByteBuffer {
     trim();
   }
 
-  boolean feed(final NioTcpChannel channel) {
+  boolean feed(final Supplier<ByteBuffer> supplier) {
     // TODO: optimization
     while (remaining < bufferSizeLimit) {
-      final ByteBuffer buffer = ByteBuffer.allocate(BUFFER_SIZE);
-      final int readSize = channel.read(buffer);
-      if (readSize <= 0) {
+      final ByteBuffer buffer = supplier.get();
+      if (buffer == null) {
         return false;
       }
 

--- a/influent-java/src/main/java/influent/internal/msgpack/MsgpackStreamUnpacker.java
+++ b/influent-java/src/main/java/influent/internal/msgpack/MsgpackStreamUnpacker.java
@@ -16,9 +16,11 @@
 
 package influent.internal.msgpack;
 
+import java.nio.ByteBuffer;
 import java.util.LinkedList;
 import java.util.NoSuchElementException;
 import java.util.Queue;
+import java.util.function.Supplier;
 
 import org.msgpack.value.ImmutableValue;
 
@@ -54,14 +56,15 @@ public final class MsgpackStreamUnpacker {
   /**
    * Reads buffers from a {@code ReadableByteChannel}.
    *
+   * @param supplier supplier to produce ByteBuffer
    * @param channel channel
    * @throws InfluentIOException when it fails reading from the channel
    *                             or the chunk size exceeds the limit
    */
-  public void feed(final NioTcpChannel channel) {
+  public void feed(final Supplier<ByteBuffer> supplier, final NioTcpChannel channel) {
     boolean toBeContinued = true;
     while (toBeContinued) {
-      toBeContinued = buffer.feed(channel);
+      toBeContinued = buffer.feed(supplier);
       unpack(channel);
     }
   }

--- a/influent-java/src/test/scala/influent/forward/NioForwardConnectionSpec.scala
+++ b/influent-java/src/test/scala/influent/forward/NioForwardConnectionSpec.scala
@@ -26,9 +26,11 @@ import java.nio.channels.SelectionKey
 import java.util
 import java.util.Optional
 import java.util.concurrent.CompletableFuture
-import org.mockito.AdditionalAnswers
+import java.util.function.Supplier
+import org.mockito.ArgumentMatchers._
 import org.mockito.Mockito._
 import org.mockito.stubbing.Answer1
+import org.mockito.{AdditionalAnswers, ArgumentMatchers}
 import org.msgpack.core.MessagePack
 import org.msgpack.value.impl.ImmutableStringValueImpl
 import org.scalatest.WordSpec
@@ -351,7 +353,8 @@ class NioForwardConnectionSpec extends WordSpec with MockitoSugar {
         val callback = mock[ForwardCallback]
         val channel = mock[NioTcpChannel]
         val unpacker = mock[MsgpackStreamUnpacker]
-        when(unpacker.feed(channel)).thenThrow(new InfluentIOException())
+        when(unpacker.feed(any[Supplier[ByteBuffer]], ArgumentMatchers.eq[NioTcpChannel](channel)))
+          .thenThrow(new InfluentIOException())
         val connection = new NioForwardConnection(
           channel, mock[NioEventLoop], callback, unpacker, mock[MsgpackForwardRequestDecoder]
         )

--- a/influent-java/src/test/scala/influent/internal/msgpack/MsgpackIncrementalUnpackerSpec.scala
+++ b/influent-java/src/test/scala/influent/internal/msgpack/MsgpackIncrementalUnpackerSpec.scala
@@ -41,7 +41,7 @@ class MsgpackIncrementalUnpackerSpec extends WordSpec with GeneratorDrivenProper
           val chunks = asBytes.grouped(groupSize).toList
           chunks.init.foreach { bytes =>
             val buf = ByteBuffer.allocate(1024)
-            buf.put(bytes)
+            buf.put(bytes).flip()
             buffer.push(buf)
             val result = unpacker.unpack(buffer)
             assert(!result.isCompleted)
@@ -49,7 +49,7 @@ class MsgpackIncrementalUnpackerSpec extends WordSpec with GeneratorDrivenProper
           }
 
           val buf = ByteBuffer.allocate(1024)
-          buf.put(chunks.last)
+          buf.put(chunks.last).flip()
           buffer.push(buf)
 
           val actual = unpacker.unpack(buffer)

--- a/influent-transport/src/main/java/influent/internal/nio/NioEventLoopTask.java
+++ b/influent-transport/src/main/java/influent/internal/nio/NioEventLoopTask.java
@@ -26,6 +26,7 @@ import java.nio.channels.SelectionKey;
 import java.nio.channels.Selector;
 import java.util.Iterator;
 import java.util.Set;
+import java.util.function.BooleanSupplier;
 import java.util.function.IntUnaryOperator;
 
 import org.slf4j.Logger;
@@ -141,7 +142,11 @@ interface NioEventLoopTask {
           if (key.isConnectable()) {
             attachment.onConnectable(key);
           }
+        } catch (final CancelledKeyException e) {
+          logger.debug("The key has already been cancelled.");
+          Exceptions.ignore(attachment::close, "Failed closing " + attachment);
         } catch (final Exception e) {
+          logger.debug("An error occurred when handling an event.", e);
           Exceptions.ignore(attachment::close, "Failed closing " + attachment);
         }
 


### PR DESCRIPTION
Invoke all read operation on NioForwardConnection.
SSL/TLS handshake requires operations to Selector,
so it is difficult to invoke some I/O on Unpacker.