### PR TITLE
add jdk11 test instead of 9. use openjdk

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,12 @@
 language: scala
 
+dist: xenial
+
 script:
   - sbt -J-Xmx3784m test
 
 jdk:
-  - oraclejdk8
-  - oraclejdk9
+  - openjdk8
+  - openjdk11
 
 sudo: true

--- a/build.sbt
+++ b/build.sbt
@@ -44,7 +44,7 @@ lazy val commonSettings = Seq(
   javacOptions in (Compile, compile) ++= Seq("-encoding", "UTF-8"),
   libraryDependencies ++= Seq(
     "org.slf4j" % "slf4j-api" % "1.7.25",
-    "org.mockito" % "mockito-core" % "2.21.0" % "test",
+    "org.mockito" % "mockito-core" % "2.28.2" % "test",
     "org.scalatest" %% "scalatest" % "3.0.5" % "test",
     "org.scalacheck" %% "scalacheck" % "1.14.0" % "test"
   ),


### PR DESCRIPTION
https://blog.travis-ci.com/2018-11-08-xenial-release

https://github.com/travis-ci/travis-ci/issues/10290#issuecomment-432331802

> oraclejdk8 is not preinstalled on Xenial anymore, and cannot be retrieved from Oracle itself anymore. We'd suggest using either openjdk, or the currently supported Oracle JDK.